### PR TITLE
Need FluentFTP pckg/lib installed for chmod to work

### DIFF
--- a/WpfApplication1/FTPClient.csproj
+++ b/WpfApplication1/FTPClient.csproj
@@ -84,6 +84,7 @@
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
     </ApplicationDefinition>
+    <Compile Include="chmod.cs" />
     <Compile Include="copyDir.cs" />
     <Compile Include="removeDir.cs" />
     <Compile Include="removeFile.cs" />

--- a/WpfApplication1/FTPClientViewModel.cs
+++ b/WpfApplication1/FTPClientViewModel.cs
@@ -59,9 +59,24 @@ namespace WpfApplication1
             this.CopyDirectory = new Command(ced => true, ed => CopyCertainDirectory.DirectoryCopy(HostName, UserName, Password, SourceDirName, DestDirName));
             this.SaveUserInfo = new Command(ced => true, ed => history.writeUserLog(HostName, UserName, Password, Port));
             ClientModel.ToggleProgressBar += FTPClientModel_ToggleProgressBar;
-        }
+        } 
+        
+        
+        /// <summary>
+       /// Gets or sets the permission of a file/dir
+       /// </summary>
+       private string _permission = string.Empty;
+       public string Permission
+       {
+           get => _permission;
+           set
+           {
+               _permission = value;
+               this.OnPropertyChanged(() => this.Permission);
+           }
+       }
 
-
+    
         /// <summary>
         /// Toggles the progress bar
         /// </summary>


### PR DESCRIPTION
Following the documentation of FluentFTP, the newly added chmod class should work after the button is made and the FluentFTP package/library is added to the project. I tried adding it to "package.config" by using this command: <Package id="FluentFTP" version="27.0.2" targetFramework="net452" />, but had no luck there. Hoping someone that actually knows C# can save me a little trouble, assuming it is a simple fix. Sorry for the trouble though.

Here is a link to the library/package:
https://github.com/robinrodricks/FluentFTP/tree/master/FluentFTP
